### PR TITLE
feat: whoops, I forgot to implement sprite rotation

### DIFF
--- a/Engine/include/Rendering/GameSprite.h
+++ b/Engine/include/Rendering/GameSprite.h
@@ -2,11 +2,11 @@
 #define GAMESPRITE_H
 
 #ifdef _WIN32
-    #include <SDL_image.h>
+#include <SDL_image.h>
 #elif __APPLE__
-    #include <SDL_image.h>
+#include <SDL_image.h>
 #else
-    #include <SDL2/SDL_image.h>
+#include <SDL2/SDL_image.h>
 #endif
 #include "Util/Rect.h"
 #include <Util/RotatedRectangle.h>
@@ -29,7 +29,7 @@ enum Direction
 class GameSprite : public Drawable
 {
 public:
-    GameSprite(const Rect &dimensions, const Point &clipLocation, SDL_Texture *texture);
+    GameSprite(const Rect &dimensions, const Point &clipLocation, SDL_Texture *texture, float rotationAngle);
 
     void SetSize(int width, int height);
     void SetTexture(SDL_Texture *texture);

--- a/Engine/src/Game/Ball.cpp
+++ b/Engine/src/Game/Ball.cpp
@@ -1,6 +1,6 @@
 #include "Game/Ball.h"
 
-Ball::Ball(const Rect &dimensions, const Point &clipLocation, SDL_Texture *texture) : GameSprite(dimensions, clipLocation, texture)
+Ball::Ball(const Rect &dimensions, const Point &clipLocation, SDL_Texture *texture) : GameSprite(dimensions, clipLocation, texture, 0)
 {
     // ctor
     Alive(true);

--- a/Engine/src/Game/Crate.cpp
+++ b/Engine/src/Game/Crate.cpp
@@ -1,6 +1,6 @@
 #include "Game/Crate.h"
 
-Crate::Crate(const Rect &dimensions, int crateType) : GameSprite(dimensions, Point(0, 0), NULL)
+Crate::Crate(const Rect &dimensions, int crateType) : GameSprite(dimensions, Point(0, 0), NULL, 0)
 {
     // ctor
     Alive(true);

--- a/Engine/src/Game/Paddle.cpp
+++ b/Engine/src/Game/Paddle.cpp
@@ -1,6 +1,6 @@
 #include "Game/Paddle.h"
 
-Paddle::Paddle(const Rect &dimensions, const Point &clipLocation, SDL_Texture *texture) : GameSprite(dimensions, clipLocation, texture)
+Paddle::Paddle(const Rect &dimensions, const Point &clipLocation, SDL_Texture *texture) : GameSprite(dimensions, clipLocation, texture, 0)
 {
     // ctor
     Alive(true);

--- a/Engine/src/Game/Tile.cpp
+++ b/Engine/src/Game/Tile.cpp
@@ -1,6 +1,6 @@
 #include "Game/Tile.h"
 
-Tile::Tile(const Rect &dimensions, const Point &clip) : GameSprite(dimensions, clip, NULL)
+Tile::Tile(const Rect &dimensions, const Point &clip) : GameSprite(dimensions, clip, NULL, 0)
 {
     m_type = 0;
 

--- a/Engine/src/Rendering/GameSprite.cpp
+++ b/Engine/src/Rendering/GameSprite.cpp
@@ -11,14 +11,14 @@ GameSprite::~GameSprite()
         m_bounds = NULL;
     }
 }
-GameSprite::GameSprite(const Rect &dimensions, const Point &clipLocation, SDL_Texture *texture)
+GameSprite::GameSprite(const Rect &dimensions, const Point &clipLocation, SDL_Texture *texture, float rotationAngle)
 {
     // init the inner sprite, setup start params
     this->m_texture = texture;
     this->m_worldX = dimensions.X();
     this->m_worldY = dimensions.Y();
 
-    this->m_bounds = new RotatedRectangle(Rect(dimensions.X(), dimensions.Y(), dimensions.Width(), dimensions.Height()), 0.0f);
+    this->m_bounds = new RotatedRectangle(Rect(dimensions.X(), dimensions.Y(), dimensions.Width(), dimensions.Height()), rotationAngle);
 
     this->m_width = dimensions.Width();
     this->m_height = dimensions.Height();
@@ -165,7 +165,7 @@ void GameSprite::Draw(const GameWindow &win)
     {
         SDL_Rect renderLocation = {m_worldX, m_worldY, m_width, m_height};
         SDL_Rect clipRect = {m_clipX, m_clipY, m_width, m_height};
-        SDL_RenderCopy(win.m_renderer, m_texture, &clipRect, &renderLocation);
+        SDL_RenderCopyEx(win.m_renderer, m_texture, &clipRect, &renderLocation, m_bounds->Rotation(), NULL, SDL_FLIP_NONE);
     }
     if (Animating())
     {

--- a/Engine/src/States/GameOverState.cpp
+++ b/Engine/src/States/GameOverState.cpp
@@ -73,7 +73,7 @@ void GameOverState::InitState()
     ImageResourceManager::LoadImageResource("gameover_lose", "assets/img/gameover_lose.png", gameWin->m_renderer);
     ImageResourceManager::LoadImageResource("gameover_win", "assets/img/gameover_win.png", gameWin->m_renderer);
 
-    m_backdrop = new GameSprite(Rect(0, 0, 640, 480), Point(0, 0), NULL);
+    m_backdrop = new GameSprite(Rect(0, 0, 640, 480), Point(0, 0), NULL, 0);
 }
 
 void GameOverState::EndState()

--- a/Engine/src/States/MainMenuState.cpp
+++ b/Engine/src/States/MainMenuState.cpp
@@ -68,7 +68,7 @@ void MainMenuState::InitState()
     GameWindow *gameWin = m_engineInstance->GetGameWindow();
     ImageResourceManager::LoadImageResource("StartScreen", "assets/img/titlescreen.png", gameWin->m_renderer);
     m_theme = AudioResourceManager::LoadMusicResource("GameTheme", "assets/music/theme.wav");
-    m_titlescreen = new GameSprite(Rect(0, 0, 640, 480), Point(0, 0), ImageResourceManager::GetImageResource("StartScreen"));
+    m_titlescreen = new GameSprite(Rect(0, 0, 640, 480), Point(0, 0), ImageResourceManager::GetImageResource("StartScreen"), 0);
 }
 void MainMenuState::EndState()
 {

--- a/Engine/src/States/RandomRebound_GameState.cpp
+++ b/Engine/src/States/RandomRebound_GameState.cpp
@@ -396,10 +396,10 @@ void RandomRebound_GameState::InitState()
     m_gameBall = new Ball(Rect(312, 232, 16, 16), Point(0, 0), ImageResourceManager::GetImageResource("ball_temple"));
     m_player = new Paddle(Rect(280, 438, 96, 16), Point(0, 0), ImageResourceManager::GetImageResource("paddle_temple"));
     m_opponent = new Paddle(Rect(280, 32, 96, 16), Point(0, 0), ImageResourceManager::GetImageResource("paddle_temple"));
-    m_backdrop = new GameSprite(Rect(0, 0, 640, 480), Point(0, 0), ImageResourceManager::GetImageResource("backdrop_temple"));
+    m_backdrop = new GameSprite(Rect(0, 0, 640, 480), Point(0, 0), ImageResourceManager::GetImageResource("backdrop_temple"), 0);
 
-    m_playerScoreText = new GameSprite(Rect(80, 120, 160, 240), Point(0, 0), NULL);
-    m_opponentScoreText = new GameSprite(Rect(400, 120, 160, 240), Point(0, 0), NULL);
+    m_playerScoreText = new GameSprite(Rect(80, 120, 160, 240), Point(0, 0), NULL, 0);
+    m_opponentScoreText = new GameSprite(Rect(400, 120, 160, 240), Point(0, 0), NULL, 0);
     /* fill  play area with random crates dotted around */
     int crateMinX, crateMinY, crateWidth, crateHeight;
     crateMinX = 16;
@@ -523,21 +523,21 @@ void RandomRebound_GameState::UpdateScoreBoards()
 }
 void RandomRebound_GameState::CheckOpponentBounds()
 {
-    if ( m_opponent->Bounds().X() - m_opponent->XSpeed() > m_minPaddleX)
+    if (m_opponent->Bounds().X() - m_opponent->XSpeed() > m_minPaddleX)
     {
         m_opponent->Move(DIRECTION_LEFT);
     }
-    else if ( m_opponent->Bounds().X() - m_opponent->XSpeed() < m_opponent->XSpeed())
+    else if (m_opponent->Bounds().X() - m_opponent->XSpeed() < m_opponent->XSpeed())
     {
-        m_opponent->SetPosition(m_minPaddleX + 20,  m_opponent->Bounds().Y());
+        m_opponent->SetPosition(m_minPaddleX + 20, m_opponent->Bounds().Y());
     }
-    if ( m_opponent->Bounds().X() +  m_opponent->Bounds().Width() < m_maxPaddleX)
+    if (m_opponent->Bounds().X() + m_opponent->Bounds().Width() < m_maxPaddleX)
     {
         m_opponent->Move(DIRECTION_RIGHT);
     }
-    else if ( m_opponent->Bounds().X() +  m_opponent->Bounds().Width() + m_opponent->XSpeed() >= m_maxPaddleX)
+    else if (m_opponent->Bounds().X() + m_opponent->Bounds().Width() + m_opponent->XSpeed() >= m_maxPaddleX)
     {
-        m_opponent->SetPosition(m_maxPaddleX -  m_opponent->Bounds().Width() - 20,  m_opponent->Bounds().Y());
+        m_opponent->SetPosition(m_maxPaddleX - m_opponent->Bounds().Width() - 20, m_opponent->Bounds().Y());
     }
 }
 void RandomRebound_GameState::ChangeTheme(int theme)


### PR DESCRIPTION
 Whoops, I forgot to implement sprite rotation when I ported the engine to SDL!

- rotated collision detection was already ported over, but needed to implement sprite rotation

- this is prep for porting some of my games that rely on rotated sprites